### PR TITLE
fix: Working containers and telegraf

### DIFF
--- a/cstr_kafka_influxdb/docker-compose.yml
+++ b/cstr_kafka_influxdb/docker-compose.yml
@@ -35,8 +35,8 @@ services:
       context: ./model
       dockerfile: Dockerfile
     depends_on:
-      - kafka
- #       condition: service_healthy
+      kafka:
+        condition: service_healthy
     ports:
       - '6066:6066'
       - '6067:6067'
@@ -50,8 +50,8 @@ services:
     volumes:
       - ./telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
     depends_on:
-      - kafka
-        #condition: service_healthy
+      kafka:
+        condition: service_healthy
     networks:
       - kafka-net
 

--- a/cstr_kafka_influxdb/docker-compose.yml
+++ b/cstr_kafka_influxdb/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3.8'
 
 services:
-
   kafka:
     image: 'bitnami/kafka:latest'
     ports:

--- a/cstr_kafka_influxdb/docker-compose.yml
+++ b/cstr_kafka_influxdb/docker-compose.yml
@@ -11,10 +11,10 @@ services:
     networks:
       - kafka-net
     healthcheck:
-     test: ["CMD-SHELL", "/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 || exit 1"]
-     interval: 10s
-     timeout: 10s
-     retries: 10
+      test: ["CMD-SHELL", "/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'

--- a/cstr_kafka_influxdb/model/pid_controller.py
+++ b/cstr_kafka_influxdb/model/pid_controller.py
@@ -9,7 +9,7 @@ app = faust.App(
     'pid_controller',
     broker='kafka://kafka:9092',
     store='memory://',
-    value_serializer='json',  
+    value_serializer='json',
     web_port=6067
 )
 
@@ -19,49 +19,49 @@ pid_control_topic = app.topic('pid_control')
 # Initial Values
 
 # Initial Values and Constant Values
-# To stop the processs after process is run a max iterations. 
+# To stop the processs after process is run a max iterations.
 process_count = 0
 max_iterations = 300
-# The setpoint that the operator will have input. The setpoint value icreases by 7.0 every 20 timesteps. 
+# The setpoint that the operator will have input. The setpoint value icreases by 7.0 every 20 timesteps.
 # setpoint = 1
-# time steps, assuming regular time series 
+# time steps, assuming regular time series
 ts = [0,0.03333]
-# Initial steady state temperature of the cooling jacket. 
+# Initial steady state temperature of the cooling jacket.
 u_ss = 300.0
 # Initial steady state temperature. Primarily used to set the desired setpoint for temperature control.
 T_ss = 324.475443431599
 # Temperature of the feed
 Tf = 350
 # Concentration A of the feed
-Caf = 1 
-# Initial setpoint of the reactor, operator controlled. The setpoint value icreases by 7.0 every 20 timesteps. 
+Caf = 1
+# Initial setpoint of the reactor, operator controlled. The setpoint value icreases by 7.0 every 20 timesteps.
 sp = u_ss
 # Inital Ca
 Ca0 = 0.87725294608097
-# Initial T 
-T0 = 324.475443431599 
+# Initial T
+T0 = 324.475443431599
 
 # PID parameters
 Kc = 9.23461230362
 tauI = 0.22836124114
-# To retain previous values 
+# To retain previous values
 T_previous = T_ss
 ie_previous = 0
 
 
-# This function implements the PID control loop for the CSTR. 
+# This function implements the PID control loop for the CSTR.
 # T_ss: Steady-state temperature.
 # u_ss: Steady-state control input.
 # t: Array of time points.
 # Tf: Feed temperature.
 # Caf: Feed concentration of A.
 # x0: Initial state vector [Ca0, T0].
-# Ca: the concentration of A in the the reactor. 
-# T: the temperature of the reactor. 
+# Ca: the concentration of A in the the reactor.
+# T: the temperature of the reactor.
 # ie: The integral of error (IE) is the accumulated sum of past errors over time. It represents the cumulative deviation of the process variable from the setpoint.
 
 # Returns: Control input (u).
-# Where the control input (u) is the temperature of the cooling jacket and the temperatuer (T) is the temperature of the tank.  
+# Where the control input (u) is the temperature of the cooling jacket and the temperatuer (T) is the temperature of the tank.
     # pid_control(T_ss, u_ss, ts, Tf, Caf, ca, t_current, sp, T_previous, ie_previous)
 def pid_control(T_ss, u_ss, ts, Tf, Caf, Ca, T, sp, ie_previous):
     """Compute the u value based on PID control."""
@@ -73,8 +73,8 @@ def pid_control(T_ss, u_ss, ts, Tf, Caf, Ca, T, sp, ie_previous):
         ie = 0.0
     P = Kc * e
     I = Kc / tauI * ie
-    print(f"delta_t: {delta_t}, e: {e}, ie_previous: {ie_previous}, ie: {ie}")  # Debugging print
-    op = u_ss + P + I 
+    print(f"[pid] delta_t: {delta_t}, e: {e}, ie_previous: {ie_previous}, ie: {ie}")  # Debugging print
+    op = u_ss + P + I
     # Upper and Lower limits on OP
     op_hi = 350.0
     op_lo = 250.0
@@ -92,12 +92,13 @@ async def process_cstr_events(events):
     global T_previous, sp, process_count, ie_previous
     # first_iteration = True
     async for event in events:
+        print(f"[pid] Received event: {event}")
         if process_count >= max_iterations:
             await app.stop()
             break
         ca_current = event.get('Ca')
         t_current = event.get('T')
-        print(f"Ca into pid: {ca_current}, T into pid: {t_current}")
+        print(f"[pid] Ca into pid: {ca_current}, T into pid: {t_current}")
         if ca_current is not None and t_current is not None:
             # if first_iteration:
             #     t_current = T_ss  # Use initial T_ss for the first iteration
@@ -111,7 +112,7 @@ async def process_cstr_events(events):
                 'setpoint': sp,
                 'ie': ie_current
             }
-            print(f"Received Ca: {ca_current}, T: {t_current}, Computed u: {u}, Setpoint: {sp}, IE: {ie_current}")
+            print(f"[pid] Received Ca: {ca_current}, T: {t_current}, Computed u: {u}, Setpoint: {sp}, IE: {ie_current}")
             await pid_control_topic.send(value=control_message)
             T_previous = t_current  # Update the previous temperature value
             ie_previous = ie_current  # Update the previous error value

--- a/cstr_kafka_influxdb/model/requirements.txt
+++ b/cstr_kafka_influxdb/model/requirements.txt
@@ -1,4 +1,7 @@
-faust-streaming
 numpy
 scipy
+# Due to some issues with the latest version of aiokafka, we are using a
+# specific version.
+faust-streaming==0.10.21
 aiokafka>=0.9.0,<0.11.0
+mode-streaming==0.3.5

--- a/cstr_kafka_influxdb/telegraf/telegraf.conf
+++ b/cstr_kafka_influxdb/telegraf/telegraf.conf
@@ -9,7 +9,7 @@
   data_format = "json_v2"
 
   [[inputs.kafka_consumer.json_v2]]
-    measurement_name = "cstr"
+    measurement_name = "cstr_data"
     [[inputs.kafka_consumer.json_v2.field]]
       path = "Ca"
       type = "float"

--- a/cstr_kafka_influxdb/telegraf/telegraf.conf
+++ b/cstr_kafka_influxdb/telegraf/telegraf.conf
@@ -5,16 +5,16 @@
 
 [[inputs.kafka_consumer]]
   brokers = ["kafka:9092"]
-  topics = ["cstr_data"]
+  topics = ["cstr"]
   data_format = "json_v2"
 
   [[inputs.kafka_consumer.json_v2]]
-    measurement_name = "cstr_data"
+    measurement_name = "cstr"
     [[inputs.kafka_consumer.json_v2.field]]
       path = "Ca"
       type = "float"
     [[inputs.kafka_consumer.json_v2.field]]
-      path = "Reactor_Temperature"
+      path = "T"
       type = "float"
 
 [[outputs.file]]


### PR DESCRIPTION
This PR includes three commits consisting of:

1) Set the faust-streaming, aiokafka, and mode-streaming python deps to certain versions. This is required as there is currently some conflicts between versions and response parsing that is occuring.
2) Updates the telegraf config to read the correct topic name and values
3) Adds some debugging prefixes to messages to help understand if the messages are coming from the model or pid controller. There is also some whitespace changes here.

This gets the app in a state, where everything comes up, the initial message is responded to and telegraf even consumes the message.

What is left: There doesn't seem to be any response or looping going on between the PID and controller. I'm not sure if the model `consume_u` function is working, but the last message I see are from the PID getting an event and responding to it:

```docker
combined_service-1  | [2024-07-25 18:47:36,594] [75] [WARNING] [pid] Received event: {'Ca': 0.87725294608097, 'T': 324.475443431599} 
combined_service-1  | [2024-07-25 18:47:36,594] [75] [WARNING] [pid] Ca into pid: 0.87725294608097, T into pid: 324.475443431599 
combined_service-1  | [2024-07-25 18:47:36,595] [75] [WARNING] [pid] delta_t: 0.03333, e: -24.47544343159899, ie_previous: 0, ie: 0.0 
combined_service-1  | [2024-07-25 18:47:36,595] [75] [WARNING] [pid] Received Ca: 0.87725294608097, T: 324.475443431599, Computed u: 250.0, Setpoint: 300.0, IE: 0.8157665295751942 
```